### PR TITLE
Players can't accidentally join a game

### DIFF
--- a/src/main/java/com/chairbender/slackbot/resistance/ResistanceBot.java
+++ b/src/main/java/com/chairbender/slackbot/resistance/ResistanceBot.java
@@ -59,7 +59,7 @@ public class ResistanceBot {
             botState.remind();
         }
         if (botState.getState().equals(BotState.State.REGISTRATION)) {
-            if (message.toLowerCase().contains("join")) {
+            if (message.equalsIgnoreCase("join")) {
                 if (botState.getPlayers().size() == 10) {
                     botState.sendPublicMessageToPlayer(resistanceMessage.getSender(), "Sorry, the player" +
                             " limit of 10 has already been reached.");


### PR DESCRIPTION
must *only* type `join` to join a game. Should prevent people that join the channel from joining by accident.